### PR TITLE
Adds data quality summary tables to quarto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ venv.bak/
 *.parquet
 *.rds
 *.xml
+
+# Quarto output
+*.html

--- a/build_datasets.R
+++ b/build_datasets.R
@@ -1,152 +1,76 @@
-
-# Load libraries ----------------------------------------------------------
-
-
-# Optionally run this right away to spin up the compute (it can take a while!)
-sconn::sc()
-
-
-
-# Data prep ---------------------------------------------------------------
-
-# Just for completeness / lineage: data now uploaded to databricks.
-
-# LSOA:LAD lookup ---------------------------------------------------------
-
-# https://github.com/francisbarton/boundr
-lsoa11_lad18_lookup_eng <- boundr::lookup("lsoa", "lad", within_year = 2018) |>
-  dplyr::filter(dplyr::if_any("lsoa11cd", \(x) grepl("^E", x)))
-
-# TODO: If I left this unfiltered, we should get a load of Welsh LAs being
-# picked up. We could then use these to impute (best guess), based on provider,
-# which nearest/most appropriate English LA we could re-allocate them to.
-# Or we get population projections for Welsh LAs as well (not currently
-# included in ppp dataset available in databricks).
-
-
-
-
-
 # Helper functions --------------------------------------------------------
 
-
-
-
 read_in_jg_data <- function(table_name) {
-  dbplyr::in_catalog("strategyunit", "csds_jg", table_name) |>
-    dplyr::tbl(src = sconn::sc())
+  sconn::sc() |>
+    dplyr::tbl(dbplyr::in_catalog("strategyunit", "csds_jg", table_name))
 }
 read_in_reference_data <- function(table_name) {
-  dbplyr::in_catalog("su_data", "reference", table_name) |>
-    dplyr::tbl(src = sconn::sc())
-}
-
-
-
-# This function was only going to be useful if we needed to summarise to
-# PatientID; but now that is out of scope.
-# commonest <- \(vec) vctrs::vec_count(vec)[["key"]][[1]]
-
-
-# List of cols to count by, possibly needs refinement!
-provider_count_cols <- \() c(
-  "provider_org_id",
-  "lad18cd",
-  "lad18nm",
-  "age_int",
-  "gender_cat"
-  ## Other columns we might want to bring in later:
-  # "TeamType",
-  # "TeamTypeDescription",
-  # "ConsultationMediumSU",
-  # "AttendanceOutcomeSU",
-)
-
-icb_count_cols <- \() c(
-  "icb22cdh",
-  "icb22nm",
-  "lad18cd",
-  "lad18nm",
-  "age_int",
-  "gender_cat"
-)
-
-
-
-
-# Use LSOA data from NHSE to allocate CSDS contacts to 2018 local authorities
-# (function currently unused below).
-match_2011_lsoas_to_2018_lads <- function(.data) {
-  lookup_tbl <- read_in_reference_data("lsoa11_lad18_lookup_eng") |>
-    dplyr::select(!"lsoa11nm")
-  .data |>
-    dplyr::left_join(lookup_tbl, "lsoa11cd")
-}
-
-
-# Summarise CSDS contacts table (function currently unused below)
-count_fin_year_care_contacts <- function(.data, fin_year_start) {
-  fys <- as.Date(paste0(as.integer(fin_year_start), "-04-01"))
-  fye <- as.Date(paste0(as.integer(fin_year_start) + 1L, "-03-31"))
-
-  .data |>
-    dplyr::filter(
-      if_any("contact_date", \(x) dplyr::between(x, {{ fys }}, {{ fye }}))
-    ) |>
-    dplyr::mutate(dplyr::across("age_int", \(x) dplyr::if_else(x > 90L, 90L, x))) |>
-    dplyr::count(dplyr::pick(all_of(count_cols())), name = "contacts")
+  sconn::sc() |>
+    dplyr::tbl(dbplyr::in_catalog("strategyunit", "default", table_name))
 }
 
 
 # Read in data tables -----------------------------------------------------
 
-
 # CSDS data as prepared by JG
 # Contains 191mn rows
 # Data for each care contact from 2021-04-01 to 2023-03-31
+# 2022/23 data: 96,647,105 rows
 csds_data_full_valid <- read_in_jg_data("full_contact_based_valid")
-lsoa11_lad18_lookup_eng <- read_in_reference_data("lsoa11_lad18_lookup_eng") |>
-  dplyr::select(!"lsoa11nm")
+lsoa11_lad18_lookup_eng <- read_in_reference_data("lsoa11_lad18_lookup_eng")
+consistent_submitters <- here::here("consistent_submitters_2022_23.csv") |>
+  readr::read_csv(col_types = "c") |>
+  dplyr::pull("provider_org_id")
 
-# 327,140 rows (by provider and LA)
-csds_contacts_2022_23_provider_summary <- csds_data_full_valid |>
-  dplyr::filter(dplyr::if_any("Der_Financial_Year", \(x) x == "2022/23")) |>
-  dplyr::rename(
-    provider_org_id = "OrgID_Provider",
-    age_int = "AgeYr_Contact_Date",
-    gender_cat = "Gender",
-    lsoa11cd = "Der_Postcode_yr2011_LSOA",
-    contact_date = "Contact_Date"
-  ) |>
-  dplyr::left_join(lsoa11_lad18_lookup_eng, "lsoa11cd") |>
-  dplyr::mutate(dplyr::across("age_int", \(x) dplyr::if_else(x > 90L, 90L, x))) |>
-  dplyr::count(dplyr::pick(tidyselect::all_of(provider_count_cols())), name = "contacts") |>
-  dplyr::collect() |>
-  dplyr::mutate(dplyr::across(c("age_int", "contacts"), as.integer))
-
-csds_contacts_2022_23_provider_summary |>
-  saveRDS("csds_contacts_provider_summary.rds")
+icb_cols <- c("icb22cdh", "icb22nm")
+dq_cols <- c("consistent", "attendance_status")
+tt <- "team_type"
+join_cols <- c("lad18cd", "age_int", "gender_cat")
 
 
-# 327,140 rows (by provider and ICB)
+# https://www.datadictionary.nhs.uk/data_elements/attendance_status.html
+# 5 - attended on time
+# 6 - attended late but was seen
+# 7 - attended late and was not seen
+# 2 - patient cancelled
+# 3 - DNA (without notice)
+# 4 - provider cancelled or postponed
+
+# 456,992 rows
 csds_contacts_2022_23_icb_summary <- csds_data_full_valid |>
   dplyr::filter(dplyr::if_any("Der_Financial_Year", \(x) x == "2022/23")) |>
-  dplyr::rename(
+  dplyr::select(
+    "icb22cdh",
+    "icb22nm",
     age_int = "AgeYr_Contact_Date",
     gender_cat = "Gender",
     lsoa11cd = "Der_Postcode_yr2011_LSOA",
-    contact_date = "Contact_Date"
+    submitter_id = "OrgID_Provider",
+    attendance_status = "AttendanceOutcomeSU",
+    team_type = "TeamTypeDescription"
   ) |>
   dplyr::left_join(lsoa11_lad18_lookup_eng, "lsoa11cd") |>
-  dplyr::mutate(dplyr::across("age_int", \(x) if_else(x > 90L, 90L, x))) |>
-  dplyr::count(dplyr::pick(tidyselect::all_of(icb_count_cols())), name = "contacts") |>
+  dplyr::mutate(
+    consistent = (submitter_id %in% {{ consistent_submitters }}),
+    dplyr::across("age_int", \(x) dplyr::if_else(x > 90L, 90L, x)),
+    dplyr::across("gender_cat", \(x) dplyr::if_else(x == "Unknown", NA, x)),
+    dplyr::across("attendance_status", \(x) {
+      dplyr::case_when(
+        x %in% c("5", "6") ~ "Attended",
+        x %in% c("3", "7") ~ "Did Not Attend",
+        x %in% c("2", "4") ~ "Cancelled",
+        .default = "Unknown"
+      )
+    }),
+    .keep = "unused"
+  ) |>
+  dplyr::count(
+    dplyr::pick(tidyselect::all_of(c(icb_cols, dq_cols, tt, join_cols))),
+    name = "contacts"
+  ) |>
   dplyr::collect() |>
-  dplyr::mutate(dplyr::across(c("age_int", "contacts"), as.integer))
-
-csds_contacts_2022_23_icb_summary |>
-  saveRDS("csds_contacts_2022_23_icb_summary.rds")
-
-
+  dplyr::mutate(dplyr::across(c("age_int", "contacts"), as.integer)) |>
+  readr::write_rds("csds_contacts_icb_summary.rds")
 
 
 # Population projections data ---------------------------------------------
@@ -158,7 +82,7 @@ popn_proj_orig <- sconn::sc() |>
 
 # 1,305,304 rows
 popn_proj_tidy <- popn_proj_orig |>
-  dplyr::filter(if_any("year", \(x) x >= 2022L)) |>
+  dplyr::filter(dplyr::if_any("year", \(x) x >= 2022L)) |>
   dplyr::select(c(
     cal_yr = "year",
     lad18cd = "area_code",
@@ -168,7 +92,7 @@ popn_proj_tidy <- popn_proj_orig |>
   )) |>
   dplyr::collect() |>
   dplyr::mutate(
-    dplyr::across("gender_cat", \(x) if_else(x == 1L, "Male", "Female")),
+    dplyr::across("gender_cat", \(x) dplyr::if_else(x == 1L, "Male", "Female")),
     dplyr::across("gender_cat", as.factor),
     dplyr::across(c("age_int", "cal_yr"), as.integer),
     dplyr::across("value", as.numeric)
@@ -179,39 +103,126 @@ popn_proj_tidy <- popn_proj_orig |>
   readr::write_rds("popn_proj_tidy.rds")
 
 
-
-
 # Calculate growth coefficients per financial year ------------------------
-
-
 
 # 1,245,972 rows
 popn_fy_projected <- readr::read_rds("popn_proj_tidy.rds") |>
   dplyr::mutate(
-    fin_year = paste0(.data[["cal_yr"]], "_", dplyr::lead(.data[["cal_yr"]]) %% 100),
-    fin_year_popn = (.data[["value"]] * 0.75) + (dplyr::lead(.data[["value"]]) * 0.25),
-    growth_coeff = .data[["fin_year_popn"]] / dplyr::first(.data[["fin_year_popn"]]),
+    fin_year = paste0(
+      .data[["cal_yr"]],
+      "_",
+      dplyr::lead(.data[["cal_yr"]]) %% 100
+    ),
+    fin_year_popn = (.data[["value"]] * 0.75) +
+      (dplyr::lead(.data[["value"]]) * 0.25),
+    growth_coeff = .data[["fin_year_popn"]] /
+      dplyr::first(.data[["fin_year_popn"]]),
     .by = tidyselect::all_of(c("lad18cd", "age_int", "gender_cat")),
     .keep = "unused"
   ) |>
   dplyr::filter(!dplyr::if_any("fin_year_popn", is.na))
 
 
-
 # Calculate projected community contacts ----------------------------------
 
-join_popn_proj_data <- function(x, y = popn_fy_projected) {
-  x |>
-    dplyr::left_join(y, join_cols) |>
+join_popn_proj_data <- function(dat, nat = FALSE, y = popn_fy_projected) {
+  ncmi <- if (nat) "nat_contacts_missing_icb" else NULL
+  join_cols <- c("lad18cd", "age_int", "gender_cat")
+  sum_con <- \(x) sum(x[["contacts"]])
+  all_icb_contacts <- sum_con(dat)
+  missing_gen <- sum_con(dplyr::filter(dat, dplyr::if_any("gender_cat", is.na)))
+  missing_age <- sum_con(dplyr::filter(dat, dplyr::if_any("age_int", is.na)))
+  inconsistnt <- sum_con(dplyr::filter(dat, !dplyr::if_any("consistent")))
+  not_attnded <- dat |>
+    dplyr::filter(
+      dplyr::if_any("attendance_status", \(x) x == "Did Not Attend")
+    ) |>
+    sum_con()
+  canclld_unk <- dat |>
+    dplyr::filter(
+      dplyr::if_any("attendance_status", \(x) x %in% c("Cancelled", "Unknown"))
+    ) |>
+    sum_con()
+
+  dat_filtered <- dat |>
+    dplyr::filter(
+      dplyr::if_all(tidyselect::all_of(join_cols), \(x) !is.na(x)) &
+        dplyr::if_any("attendance_status", \(x) x == "Attended") &
+        dplyr::if_any("consistent")
+    ) |>
+    dplyr::summarise(
+      across("contacts", sum),
+      .by = c(tidyselect::all_of(c(join_cols, ncmi)), "team_type")
+    )
+  icb_contacts_filt <- sum_con(dat_filtered)
+
+  projected_contacts_by_fy <- dat_filtered |>
+    dplyr::left_join(y, join_cols, relationship = "many-to-many") |>
     dplyr::mutate(
       projected_contacts = .data[["contacts"]] * .data[["growth_coeff"]],
       .keep = "unused"
     )
+
+  fy_age_summary <- projected_contacts_by_fy |>
+    dplyr::summarise(
+      across(c("fin_year_popn", "projected_contacts"), sum),
+      .by = c(tidyselect::all_of(ncmi), "fin_year", "age_int")
+    ) |>
+    dplyr::rename(
+      proj_popn_by_fy_age = "fin_year_popn",
+      proj_contacts_by_fy_age = "projected_contacts"
+    )
+
+  projected_contacts_by_fy |>
+    dplyr::summarise(
+      across("projected_contacts", sum),
+      .by = c("fin_year", "age_int", "team_type")
+    ) |>
+    dplyr::left_join(fy_age_summary, c("fin_year", "age_int")) |>
+    dplyr::mutate(
+      icb_contacts_all_unfiltd = all_icb_contacts,
+      icb_contacts_missing_gen = missing_gen,
+      icb_contacts_missing_age = missing_age,
+      icb_contacts_inconsistnt = inconsistnt,
+      icb_contacts_not_attnded = not_attnded,
+      icb_contacts_canclld_unk = canclld_unk,
+      icb_contacts_total_excld = all_icb_contacts - icb_contacts_filt,
+      icb_contacts_final_count = icb_contacts_filt,
+      .before = "fin_year"
+    ) |>
+    dplyr::arrange(dplyr::pick(c("fin_year", "age_int")))
 }
 
 
-contacts_fy_projected_icb <- readr::read_rds("csds_contacts_icb_summary.rds") |>
-  # Nesting creates a list-col "data", with a single tibble per row (per ICB)
-  tidyr::nest(.by = tidyselect::all_of(c(icb_cols, dq_cols))) |>
+nat_projected_contacts_fy <- readr::read_rds("csds_contacts_icb_summary.rds") |>
+  # fmt: skip
+  dplyr::mutate(
+    nat_contacts_missing_icb = sum(dplyr::if_else(
+      is.na(.data$icb22cdh), .data$contacts, 0L
+    ))
+  ) |>
+  join_popn_proj_data(nat = TRUE) |>
+  dplyr::rename_with(\(x) sub("^icb", "nat", x)) |>
+  dplyr::relocate("nat_contacts_missing_icb", .after = 1) |>
+  tidyr::nest(.by = tidyselect::starts_with("nat_contacts")) |>
+  readr::write_rds("nat_projected_contacts_fy.rds")
+
+
+hoist_cols <- c(
+  "icb_contacts_all_unfiltd",
+  "icb_contacts_missing_gen",
+  "icb_contacts_missing_age",
+  "icb_contacts_inconsistnt",
+  "icb_contacts_not_attnded",
+  "icb_contacts_canclld_unk",
+  "icb_contacts_total_excld",
+  "icb_contacts_final_count"
+)
+
+
+icb_projected_contacts_fy <- readr::read_rds("csds_contacts_icb_summary.rds") |>
+  dplyr::filter(!dplyr::if_any("icb22cdh", is.na)) |>
+  tidyr::nest(.by = c(tidyselect::all_of(icb_cols))) |>
   dplyr::mutate(across("data", \(x) purrr::map(x, join_popn_proj_data))) |>
-  readr::write_rds("contacts_fy_projected_icb.rds")
+  tidyr::hoist("data", !!!hoist_cols, .transform = unique) |>
+  readr::write_rds("icb_projected_contacts_fy.rds")

--- a/build_datasets.R
+++ b/build_datasets.R
@@ -151,11 +151,10 @@ csds_contacts_2022_23_icb_summary |>
 
 # Population projections data ---------------------------------------------
 
-
-ppp_locn <- "/Volumes/su_data/nhp/population-projections/demographic_data"
-
+pps_folder <- "/Volumes/su_data/nhp/population-projections/demographic_data/"
+ppp_location <- paste0(pps_folder, "projection=principal_proj")
 popn_proj_orig <- sconn::sc() |>
-  sparklyr::spark_read_parquet("popn_proj_data", ppp_locn)
+  sparklyr::spark_read_parquet("popn_proj_data", ppp_location)
 
 # 1,305,304 rows
 popn_proj_tidy <- popn_proj_orig |>

--- a/communities_demographic_growth_tool.qmd
+++ b/communities_demographic_growth_tool.qmd
@@ -3,7 +3,7 @@ title: |
   Community Services: Projected Demographic Growth
 subtitle: Projected care contacts to 2042-43, based on the 2022-23 CSDS dataset
 author:
-  name: Fran Barton
+  name: Fran Barton, Rhian Davies
   email: francis.barton1@nhs.net
 date: today
 lang: en-GB
@@ -43,89 +43,104 @@ library(ggplot2)
 library(glue)
 library(gt)
 library(ragg)
+library(rlang)
 library(scales)
 library(StrategyUnitTheme)
 library(stringr)
 library(systemfonts)
 
-contacts_data <- readr::read_rds("contacts_fy_projected_icb.rds")
+selected_icb <- "QUA" # Black Country
+
+icb_data <- readr::read_rds("icb_projected_contacts_fy.rds") |>
+  dplyr::mutate(
+    across("icb22nm", \(x) sub("^(NHS )(.*)( Integ.*)$", "\\2 ICB", x))
+  ) |>
+  dplyr::filter(dplyr::if_any("icb22cdh", \(x) x == {{ selected_icb }}))
+national_data <- readr::read_rds("nat_projected_contacts_fy.rds")
+
+icb_contacts_data <- icb_data[["data"]][[1]]
+nat_contacts_data <- national_data[["data"]][[1]]
+
+icb_name <- icb_data[["icb22nm"]]
+
 
 text_grey <- "#3e3f3a" # sandstone theme default text colour
-# text_grey <- su_theme_cols("light_charcoal")
-# text_grey <- "grey35"
 
 su_chart_theme <- function(font_family = "Segoe UI") {
   text_grey <- "#3e3f3a"
   light_bkg <- "#faf0e6" # aka "linen"
-  # su_slate <- su_theme_cols("light_slate")
   dark_slate <- su_theme_cols("dark_slate")
-  # l_orange <- su_theme_cols("light_orange")
   loran_tr <- "#fcdf8377" # su_theme_cols("light_orange") with transparency
   slate_tr <- "#b2b7b977" # su_theme_cols("light_slate") with transparency
-  # coral_tr <- "#ff7f5077" # R coral with transparency
   ggplot2::theme(
-    text = element_text(family = font_family, size = 20, colour = text_grey),
-    title = element_text(hjust = 0.05),
-    plot.title = element_text(size = 28, margin = margin(20, 8, 12, 18)),
-    plot.subtitle = element_text(margin = margin(2, 0, 12, 20)),
-    plot.caption = element_text(
+    text = ggplot2::element_text(
+      family = font_family,
+      size = 20,
+      colour = text_grey
+    ),
+    title = ggplot2::element_text(hjust = 0.05),
+    plot.title = ggplot2::element_text(
+      size = 28,
+      margin = ggplot2::margin(20, 8, 12, 18)
+    ),
+    plot.subtitle = ggplot2::element_text(
+      margin = ggplot2::margin(2, 0, 12, 20)
+    ),
+    plot.caption = ggplot2::element_text(
       hjust = 0.96,
       size = 16,
-      margin = margin(12, 6, 6, 0)
+      margin = ggplot2::margin(12, 6, 6, 0)
     ),
     plot.title.position = "plot",
     plot.caption.position = "plot",
-    plot.background = element_rect(fill = light_bkg, colour = NA),
-    plot.margin = margin(6, 24, 6, 6),
-    panel.background = element_rect(fill = light_bkg),
-    legend.title = element_text(hjust = 0, margin = margin(b = 8)),
-    legend.background = element_rect(fill = light_bkg),
-    # legend.margin = margin(r = 30),
-    legend.key = element_rect(fill = light_bkg),
+    plot.background = ggplot2::element_rect(fill = light_bkg, colour = NA),
+    plot.margin = ggplot2::margin(6, 24, 6, 6),
+    panel.background = ggplot2::element_rect(fill = light_bkg),
+    legend.position = "bottom",
+    legend.title.position = "top",
+    legend.title = ggplot2::element_text(
+      hjust = 0,
+      margin = ggplot2::margin(b = 8)
+    ),
+    legend.text.position = "bottom",
+    legend.background = ggplot2::element_rect(fill = light_bkg),
+    legend.key = ggplot2::element_rect(fill = light_bkg),
     legend.key.spacing.y = grid::unit(3, "mm"),
-    legend.key.width = unit(12, "mm"),
-    legend.text = element_text(margin = margin(l = 16), hjust = 1),
-    panel.grid.major = element_line(
+    legend.key.width = grid::unit(12, "mm"),
+    legend.direction = "horizontal",
+    panel.grid.major = ggplot2::element_line(
       colour = slate_tr,
       linewidth = 0.2,
       lineend = "butt"
     ),
-    panel.grid.minor = element_line(
+    panel.grid.minor = ggplot2::element_line(
       colour = loran_tr,
       linewidth = 0.1,
       lineend = "butt"
     ),
-    # panel.grid.major = element_blank(),
-    # panel.grid.minor = element_blank(),
-    axis.line = element_blank(),
-    # axis.line = element_line(
-    #   colour = slate_tr,
-    #   linewidth = 1.5,
-    #   lineend = c("round", "butt")
-    # ),
-    axis.ticks = element_blank(),
-    # axis.ticks = element_line(
-    #   colour = slate_tr,
-    #   linewidth = 1.5,
-    #   lineend = c("round", "butt"),
-    # ),
-    axis.text.x = element_text(
-      size = 18,
-      angle = 45,
-      vjust = 0.5,
-      hjust = 0.5,
-      margin = margin(t = 8, b = 16)
+    axis.line = ggplot2::element_blank(),
+    axis.ticks.y = ggplot2::element_blank(),
+    axis.ticks.x = ggplot2::element_line(
+      colour = text_grey,
+      linewidth = 1.2,
+      lineend = "butt"
     ),
-    axis.text.y = element_text(size = 18, margin = margin(r = 8, l = 16)),
-    strip.background = element_rect(fill = dark_slate, colour = NA),
-    strip.text = element_text(colour = "grey95", size = 14),
+    axis.ticks.length = grid::unit(5, "mm"),
+    axis.minor.ticks.x.bottom = ggplot2::element_line(colour = slate_tr),
+    axis.minor.ticks.length = grid::unit(3, "mm"),
+    axis.text.x = ggplot2::element_text(
+      size = 18,
+      margin = ggplot2::margin(t = 12, b = 8)
+    ),
+    axis.text.y = ggplot2::element_text(
+      size = 18,
+      margin = ggplot2::margin(r = 12, l = 8)
+    ),
+    strip.background = ggplot2::element_rect(fill = dark_slate, colour = NA),
+    strip.text = ggplot2::element_text(colour = "grey95", size = 14),
     validate = TRUE
   )
 }
-
-selected_icb <- "QUA" # Black Country
-# selected_icb <- "QVV" # Dorset
-# selected_icb <- "QMJ" # North Central London
 
 sub_wrap <- \(..., ww = 120) stringr::str_wrap(glue::glue(..., .sep = " "), ww)
 
@@ -141,11 +156,8 @@ add_age_groups <- function(.data) {
       age_group_cat = dplyr::case_when(
         age_int == 0L ~ "0",
         age_int %in% seq(1L, 4L) ~ "1-4",
-        age_int %in% seq(5L, 9L) ~ "5-9",
-        age_int %in% seq(10L, 15L) ~ "10-15",
-        age_int %in% seq(16L, 17L) ~ "16-17",
-        age_int %in% seq(18L, 34L) ~ "18-34",
-        age_int %in% seq(35L, 49L) ~ "35-49",
+        age_int %in% seq(5L, 17L) ~ "5-17",
+        age_int %in% seq(18L, 49L) ~ "18-49",
         age_int %in% seq(50L, 64L) ~ "50-64",
         age_int %in% seq(65L, 74L) ~ "65-74",
         age_int %in% seq(75L, 84L) ~ "75-84",
@@ -161,10 +173,11 @@ add_broad_age_groups <- function(.data) {
     dplyr::arrange(dplyr::pick("age_int")) |>
     dplyr::mutate(
       broad_age_cat = dplyr::case_when(
-        age_int %in% seq(0L, 15L) ~ "0-15",
-        age_int %in% seq(16L, 49L) ~ "16-49",
-        age_int %in% seq(50L, 74L) ~ "50-74",
-        .default = "75+"
+        age_int %in% seq(0L, 4L) ~ "0-4",
+        age_int %in% seq(5L, 17L) ~ "5-17",
+        age_int %in% seq(18L, 64L) ~ "18-64",
+        age_int %in% seq(65L, 84L) ~ "65-84",
+        .default = "85+"
       ),
       across(broad_age_cat, forcats::fct_inorder),
       .keep = "unused"
@@ -175,88 +188,74 @@ add_broad_age_groups <- function(.data) {
 
 ```
 
+### Data quality summary (national)
+
+Data from the CSDS was filtered down to leave only data of sufficient quality
+  to support the calculation of projected future demand.
+
+Where any of the following items were incomplete or invalid, the contacts data
+  was filtered out:
+
+* Patient's home local authority or ICB (this includes a small number of
+    patients resident outside England)
+* Patient's recorded gender
+* Patient's age
+* Appointment attendance status
+
+Further sections of the dataset were also filtered out:
+
+* Contact appointments that were not attended, or cancelled
+* Data from submitters that submitted inconsistently over the period (2022-23)
+
+Note that contacts data that was filtered out may often have matched more than
+  one of the above criteria.
+  Hence the total contacts excluded is less than the sum of the contacts
+  excluded in each category.
+
 
 ```{r data-quality}
-national_count_contacts <- function(.data) {
-  .data |>
-    dplyr::mutate(
-      contacts = purrr::map(.data[["data"]], \(x) {
-        dplyr::summarise(x, across("projected_contacts", sum))
-      })
-    )
+create_data_quality_table <- function(dat, icb = TRUE, label) {
+  category_names <- c(
+    "All initial contacts",
+    "Contacts not attributed to an ICB",
+    "Contacts with unknown patient gender",
+    "Contacts with missing patient age",
+    "Contacts from inconsistent submitters",
+    "Contacts where the patient did not attend",
+    "Contacts where the appointment was cancelled",
+    "Total contacts excluded",
+    "Remaining contacts included in projections"
+  )
+  if (icb) category_names <- purrr::discard_at(category_names, 2)
+  row_n <- if (icb) 6 else 7
+  dat |>
+    dplyr::select(!"data") |>
+    dplyr::rename_with(\(x) category_names) |>
+    tidyr::pivot_longer(
+      cols = tidyselect::everything(),
+      names_to = "Category",
+      values_to = "n"
+    ) |>
+    dplyr::mutate(`%` = round(.data[["n"]] * 100 / .data[["n"]][[1]], 1)) |>
+    gt::gt() |>
+    gt::tab_header(glue::glue("CSDS Data Quality Summary - {label}")) |>
+    gt::tab_source_note("Source: CSDS 2022/23, NHS England") |>
+    gt::tab_footnote(
+      "This category includes appointments with unknown status",
+      gt::cells_body(1, row_n)
+    ) |>
+    gt::fmt_number(columns = "n", decimals = 0) |>
+    gt::opt_footnote_marks("standard") |>
+    gt::opt_table_font("Segoe UI", size = 18, color = text_grey) |>
+    gt::tab_options(table.width = "92%")
 }
-icb_count_contacts <- function(.data) {
-  .data |>
-    dplyr::mutate(
-      contacts = purrr::map(.data[["data"]], \(x) {
-        dplyr::summarise(x, across("projected_contacts", sum))
-      }),
-      .by = c("icb22cdh", "icb22nm")
-    )
-}
 
+national_data |>
+  create_data_quality_table(FALSE, "National")
 
-n_contacts_init <- national_count_contacts(contacts_data)
-icb_n_contacts_init <- icb_count_contacts(contacts_data)
-
-
-# Exclude rows missing patient age
-valid_age_only <- contacts_data |>
-  dplyr::mutate(
-    across("data", \(x) {
-      purrr::map(x, \(x) {
-        dplyr::filter(x, dplyr::if_any("age_int", \(x) !is.na(x)))
-      })
-    })
-  )
-
-n_contacts_valid_age <- national_count_contacts(valid_age_only)
-icb_n_contacts_valid_age <- icb_count_contacts(valid_age_only)
-
-
-# Exclude rows with missing gender or gender recorded as "Unknown"
-fm_gender_only <- contacts_data |>
-  dplyr::mutate(
-    across("data", \(x) {
-      purrr::map(x, \(x) {
-        dplyr::filter(
-          x,
-          dplyr::if_any("gender_cat", \(x) x %in% c("Female", "Male"))
-        )
-      })
-    })
-  )
-
-n_contacts_fm_gender <- national_count_contacts(fm_gender_only)
-icb_n_contacts_fm_gender <- icb_count_contacts(fm_gender_only)
-
-
-# https://www.datadictionary.nhs.uk/data_elements/attendance_status.html
-# 5 - attended on time
-# 6 - attended late but was seen
-# 7 - attended late and was not seen
-# 2 - patient cancelled
-# 3 - DNA (without notice)
-# 4 - provider cancelled or postponed
-attended_only <- contacts_data |>
-  dplyr::filter(dplyr::if_any("attendance_status", \(x) x %in% c("5", "6")))
-
-n_contacts_attended <- national_count_contacts(attended_only)
-icb_n_contacts_attended <- icb_count_contacts(attended_only)
-
-
-england_only <- contacts_data |>
-  dplyr::mutate(
-    across("data", \(x) {
-      purrr::map(x, \(x) {
-        dplyr::filter(x, dplyr::if_any("lad18cd", \(x) !is.na(x)))
-      })
-    })
-  )
-
-n_contacts_england <- national_count_contacts(england_only)
-icb_n_contacts_england <- icb_count_contacts(england_only)
-
+icb_data |>
+  dplyr::select(!tidyselect::starts_with("icb22")) |>
+  create_data_quality_table(label = icb_name)
 
 ```
 
@@ -265,54 +264,49 @@ icb_n_contacts_england <- icb_count_contacts(england_only)
 
 
 ```{r charts1}
-contacts_data <- contacts_data |>
-  dplyr::filter(if_any("consistent"))
-
-national_contacts <- contacts_data |>
-  dplyr::pull("data") |>
-  dplyr::bind_rows() |>
-  dplyr::summarise(
-    across(c("fin_year_popn", "projected_contacts"), sum),
-    .by = c("fin_year", "age_int", "gender_cat") # is gender still needed?
-  )
-
-national_contacts |>
-  add_broad_age_groups() |>
-  dplyr::summarise(
-    dplyr::across("projected_contacts", sum),
-    .by = c("fin_year", "broad_age_cat")
-  ) |>
-  ggplot2::ggplot(aes(fin_year, projected_contacts)) +
-  ggplot2::geom_line(
-    aes(colour = broad_age_cat, group = broad_age_cat),
-    linewidth = 1.8
-  ) +
-  ggplot2::labs(
-    title = "Projected contacts (national) by broad age group, 2022/23 - 2042/43",
-    caption = sub_wrap(
-      "Sources: NHS England Community Services Dataset (2022-23),",
-      "ONS Population projections"
-    ),
-    x = NULL,
-    y = NULL
-  ) +
-  ggplot2::scale_y_continuous(
-    labels = label_number(scale = 1e-6, suffix = "mn"),
-    limits = c(0, 6e7)
-  ) +
-  ggplot2::scale_x_discrete(
-    breaks = \(x) x[seq(1, length(x), 5)],
-    labels = \(x) sub("_", "/", x)
-  ) +
-  scale_colour_su(name = "Age group") +
-  su_chart_theme() +
-  ggplot2::theme(
-    legend.position = "inside",
-    legend.position.inside = c(0.9, 0.6)
-  )
+create_main_projection_chart <- function(.data, label) {
+  conv_lab <- \(x) {
+    paste0(format(x, "%Y"), "/", (as.integer(format(x, "%Y")) + 1) %% 100)
+  }
+  .data |>
+    dplyr::mutate(
+      across("fin_year", \(x) as.Date(sub("_[0-9]{2}$", "-01-01", x)))
+    ) |>
+    add_broad_age_groups() |>
+    dplyr::summarise(
+      dplyr::across("projected_contacts", sum),
+      .by = c("fin_year", "broad_age_cat")
+    ) |>
+    ggplot2::ggplot(aes(fin_year, projected_contacts)) +
+    ggplot2::geom_line(
+      ggplot2::aes(colour = broad_age_cat, group = broad_age_cat),
+      linewidth = 1.8
+    ) +
+    ggplot2::labs(
+      title = glue::glue(
+        "Projected contacts ({label}) by broad age group, 2022/23 - 2042/43"
+      ),
+      x = NULL,
+      y = NULL
+    ) +
+    ggplot2::scale_y_continuous(
+      labels = scales::label_number(scale = 1e-6, suffix = "mn")
+    ) +
+    ggplot2::scale_x_date(
+      breaks = seq.Date(as.Date("2022-01-01"), by = "5 years", length.out = 5),
+      minor_breaks = seq.Date(as.Date("2023-01-01"), as.Date("2041-01-01"), "1 year"),
+      labels = conv_lab,
+      guide = ggplot2::guide_axis(minor.ticks = TRUE)
+    ) +
+    scale_colour_su(
+      name = "Age group",
+      guide = ggplot2::guide_legend(nrow = 1)
+    ) +
+    su_chart_theme()
+}
 
 
-
+create_main_projection_chart(nat_contacts_data, "national")
 
 ```
 
@@ -321,58 +315,19 @@ national_contacts |>
 ## ICB-level contacts projection by financial year
 
 ```{r charts2}
-icb_contacts <- contacts_data |>
-  dplyr::filter(if_any("icb22cdh", \(x) x == {{ selected_icb }})) |>
-  dplyr::pull("data") |>
-  dplyr::bind_rows() |>
-  dplyr::summarise(
-    across(c("fin_year_popn", "projected_contacts"), sum),
-    .by = c("fin_year", "age_int", "gender_cat") # is gender still needed?
-  )
-
-icb_contacts |>
-  add_broad_age_groups() |>
-  dplyr::summarise(
-    dplyr::across("projected_contacts", sum),
-    .by = c("fin_year", "broad_age_cat")
-  ) |>
-  ggplot2::ggplot(aes(fin_year, projected_contacts)) +
-  ggplot2::geom_line(
-    aes(colour = broad_age_cat, group = broad_age_cat),
-    linewidth = 1.8
-  ) +
-  ggplot2::labs(
-    title = "Projected contacts (single ICB) by broad age group, 2022/23 - 2042/43",
-    caption = sub_wrap(
-      "Sources: NHS England Community Services Dataset (2022-23),",
-      "ONS Population projections"
-    ),
-    x = NULL,
-    y = NULL
-  ) +
-  ggplot2::scale_y_continuous(
-    labels = label_number(scale = 1e-3, suffix = "k"),
-    limits = c(0, NA)
-  ) +
-  ggplot2::scale_x_discrete(
-    breaks = \(x) x[seq(1, length(x), 5)],
-    labels = \(x) sub("_", "/", x)
-  ) +
-  scale_colour_su(name = "Age group") +
-  su_chart_theme()
-
-
+create_main_projection_chart(icb_contacts_data, icb_name)
 
 ```
 
 
 
-## Projected % change in total contacts over period, by age group
+## Projected % change in total contacts from baseline year to horizon year, by age group
 
-```{r, charts3}
-list(national = national_contacts, icb = icb_contacts) |>
+```{r charts3}
+list(nat_contacts_data, icb_contacts_data) |>
+  rlang::set_names(c("England", icb_name)) |>
   dplyr::bind_rows(.id = "type") |>
-  dplyr::filter(if_any("fin_year", \(x) grepl("^20[24]2", x))) |>
+  dplyr::filter(dplyr::if_any("fin_year", \(x) grepl("^20[24]2", x))) |>
   add_age_groups() |>
   dplyr::summarise(
     value = sum(.data[["projected_contacts"]]),
@@ -388,8 +343,12 @@ list(national = national_contacts, icb = icb_contacts) |>
       .data[["yr_2022_23"]],
     .keep = "unused"
   ) |>
-  ggplot2::ggplot(aes(age_group_cat, pct_change)) +
-  ggplot2::geom_col(aes(fill = type), position = "dodge", width = 0.75) +
+  ggplot2::ggplot(ggplot2::aes(age_group_cat, pct_change)) +
+  ggplot2::geom_col(
+    ggplot2::aes(fill = type),
+    position = "dodge",
+    width = 0.75
+  ) +
   ggplot2::geom_hline(yintercept = 0, linewidth = 0.4, colour = text_grey) +
   ggplot2::labs(
     title = "Projected % change in total contacts, by age group, 2022/23 - 2042/43",
@@ -399,24 +358,15 @@ list(national = national_contacts, icb = icb_contacts) |>
       "2022/23 annual contacts and projected 2042/43 annual contacts,",
       "as a percentage of 2022/23 contacts."
     ),
-    caption = sub_wrap(
-      "Sources: NHS England Community Services Dataset (2022-23),",
-      "ONS Population projections"
-    ),
     x = "Age group",
     y = "% change"
   ) +
   ggplot2::scale_y_continuous(
-    labels = label_percent(suffix = ""),
+    labels = scales::label_percent(suffix = ""),
     limits = c(-0.25, NA)
   ) +
   scale_fill_su(name = NULL) +
-  su_chart_theme() +
-  ggplot2::theme(
-    legend.position = "inside",
-    legend.position.inside = c(0.15, 0.72),
-    legend.text = element_text(margin = margin(l = 6), hjust = 0)
-  )
+  su_chart_theme()
 
 
 ```
@@ -426,41 +376,36 @@ list(national = national_contacts, icb = icb_contacts) |>
 ## Contacts per 1000 population, 2022/23, by age group
 
 ```{r charts4}
-list(national = national_contacts, icb = icb_contacts) |>
+list(nat_contacts_data, icb_contacts_data) |>
+  rlang::set_names(c("England", icb_name)) |>
   dplyr::bind_rows(.id = "type") |>
-  dplyr::filter(if_any("fin_year", \(x) x == "2022_23")) |>
+  dplyr::filter(dplyr::if_any("fin_year", \(x) x == "2022_23")) |>
+  dplyr::rename(fin_year_popn = "proj_popn_by_fy_age") |>
   add_age_groups() |>
   dplyr::summarise(
-    across(c("fin_year_popn", "projected_contacts"), sum),
+    dplyr::across(c("fin_year_popn", "projected_contacts"), sum),
     .by = c("type", "age_group_cat")
   ) |>
   dplyr::mutate(
     contacts_rate = .data[["projected_contacts"]] / .data[["fin_year_popn"]],
     .keep = "unused"
   ) |>
-  ggplot2::ggplot(aes(age_group_cat, contacts_rate)) +
-  ggplot2::geom_col(aes(fill = type), position = "dodge", width = 0.75) +
-  ggplot2::labs(
-    title = "Contacts per 1,000 population, 2022/23, by age group",
-    subtitle = sub_wrap(
-      "This chart shows the contact rate by age group within a single selected",
-      "ICB, compared to the national (England) rate."
-    ),
-    caption = sub_wrap(
-      "Sources: NHS England Community Services Dataset (2022-23),",
-      "ONS Population projections"
-    ),
-    x = "Age group",
-    y = "Contacts / 1000 people"
+  ggplot2::ggplot(ggplot2::aes(age_group_cat, contacts_rate)) +
+  ggplot2::geom_col(
+    ggplot2::aes(fill = type),
+    position = "dodge",
+    width = 0.75
   ) +
-  ggplot2::scale_y_continuous(labels = label_number(scale = 1e3)) +
+  ggplot2::labs(
+    title = "Contacts per 1000 population, 2022/23, by age group",
+    x = "Age group",
+    y = "Contacts / 1000 population"
+  ) +
+  ggplot2::scale_y_continuous(
+    labels = scales::label_number(scale = 1e3, suffix = "k")
+  ) +
   scale_fill_su(name = NULL) +
-  su_chart_theme() +
-  ggplot2::theme(
-    legend.position = "inside",
-    legend.position.inside = c(0.15, 0.72),
-    legend.text = element_text(margin = margin(l = 6), hjust = 0)
-  )
+  su_chart_theme()
 
 
 ```

--- a/communities_demographic_growth_tool.qmd
+++ b/communities_demographic_growth_tool.qmd
@@ -1,0 +1,466 @@
+---
+title: |
+  Community Services: Projected Demographic Growth
+subtitle: Projected care contacts to 2042-43, based on the 2022-23 CSDS dataset
+author:
+  name: Fran Barton
+  email: francis.barton1@nhs.net
+date: today
+lang: en-GB
+theme: sandstone
+mainfont: "Segoe UI"
+lightbox: true
+embed-resources: true
+fig-dpi: 108
+fig-height: 10
+fig-width: 16.18
+fig-responsive: true
+out-width: 92%
+execute:
+  warning: false
+  echo: false
+knitr:
+  opts_chunk:
+    dev: "ragg_png"
+---
+
+```{scss}
+
+:root {
+  // --bs-body-color: #9d928a; // SU "light charcoal" palette colour
+  // --bs-body-color: #595959; // R colour grey35
+  --bs-body-color: #3e3f3a; // bootswatch default grey
+  --bs-body-bg: #faf0e6; // "linen"
+}
+
+```
+
+
+```{r setup}
+library(dplyr)
+library(forcats)
+library(ggplot2)
+library(glue)
+library(gt)
+library(ragg)
+library(scales)
+library(StrategyUnitTheme)
+library(stringr)
+library(systemfonts)
+
+contacts_data <- readr::read_rds("contacts_fy_projected_icb.rds")
+
+text_grey <- "#3e3f3a" # sandstone theme default text colour
+# text_grey <- su_theme_cols("light_charcoal")
+# text_grey <- "grey35"
+
+su_chart_theme <- function(font_family = "Segoe UI") {
+  text_grey <- "#3e3f3a"
+  light_bkg <- "#faf0e6" # aka "linen"
+  # su_slate <- su_theme_cols("light_slate")
+  dark_slate <- su_theme_cols("dark_slate")
+  # l_orange <- su_theme_cols("light_orange")
+  loran_tr <- "#fcdf8377" # su_theme_cols("light_orange") with transparency
+  slate_tr <- "#b2b7b977" # su_theme_cols("light_slate") with transparency
+  # coral_tr <- "#ff7f5077" # R coral with transparency
+  ggplot2::theme(
+    text = element_text(family = font_family, size = 20, colour = text_grey),
+    title = element_text(hjust = 0.05),
+    plot.title = element_text(size = 28, margin = margin(20, 8, 12, 18)),
+    plot.subtitle = element_text(margin = margin(2, 0, 12, 20)),
+    plot.caption = element_text(
+      hjust = 0.96,
+      size = 16,
+      margin = margin(12, 6, 6, 0)
+    ),
+    plot.title.position = "plot",
+    plot.caption.position = "plot",
+    plot.background = element_rect(fill = light_bkg, colour = NA),
+    plot.margin = margin(6, 24, 6, 6),
+    panel.background = element_rect(fill = light_bkg),
+    legend.title = element_text(hjust = 0, margin = margin(b = 8)),
+    legend.background = element_rect(fill = light_bkg),
+    # legend.margin = margin(r = 30),
+    legend.key = element_rect(fill = light_bkg),
+    legend.key.spacing.y = grid::unit(3, "mm"),
+    legend.key.width = unit(12, "mm"),
+    legend.text = element_text(margin = margin(l = 16), hjust = 1),
+    panel.grid.major = element_line(
+      colour = slate_tr,
+      linewidth = 0.2,
+      lineend = "butt"
+    ),
+    panel.grid.minor = element_line(
+      colour = loran_tr,
+      linewidth = 0.1,
+      lineend = "butt"
+    ),
+    # panel.grid.major = element_blank(),
+    # panel.grid.minor = element_blank(),
+    axis.line = element_blank(),
+    # axis.line = element_line(
+    #   colour = slate_tr,
+    #   linewidth = 1.5,
+    #   lineend = c("round", "butt")
+    # ),
+    axis.ticks = element_blank(),
+    # axis.ticks = element_line(
+    #   colour = slate_tr,
+    #   linewidth = 1.5,
+    #   lineend = c("round", "butt"),
+    # ),
+    axis.text.x = element_text(
+      size = 18,
+      angle = 45,
+      vjust = 0.5,
+      hjust = 0.5,
+      margin = margin(t = 8, b = 16)
+    ),
+    axis.text.y = element_text(size = 18, margin = margin(r = 8, l = 16)),
+    strip.background = element_rect(fill = dark_slate, colour = NA),
+    strip.text = element_text(colour = "grey95", size = 14),
+    validate = TRUE
+  )
+}
+
+selected_icb <- "QUA" # Black Country
+# selected_icb <- "QVV" # Dorset
+# selected_icb <- "QMJ" # North Central London
+
+sub_wrap <- \(..., ww = 120) stringr::str_wrap(glue::glue(..., .sep = " "), ww)
+
+```
+
+
+```{r data-summary-functions}
+
+add_age_groups <- function(.data) {
+  .data |>
+    dplyr::arrange(dplyr::pick("age_int")) |>
+    dplyr::mutate(
+      age_group_cat = dplyr::case_when(
+        age_int == 0L ~ "0",
+        age_int %in% seq(1L, 4L) ~ "1-4",
+        age_int %in% seq(5L, 9L) ~ "5-9",
+        age_int %in% seq(10L, 15L) ~ "10-15",
+        age_int %in% seq(16L, 17L) ~ "16-17",
+        age_int %in% seq(18L, 34L) ~ "18-34",
+        age_int %in% seq(35L, 49L) ~ "35-49",
+        age_int %in% seq(50L, 64L) ~ "50-64",
+        age_int %in% seq(65L, 74L) ~ "65-74",
+        age_int %in% seq(75L, 84L) ~ "75-84",
+        .default = "85+"
+      ),
+      across(age_group_cat, forcats::fct_inorder),
+      .keep = "unused"
+    )
+}
+
+add_broad_age_groups <- function(.data) {
+  .data |>
+    dplyr::arrange(dplyr::pick("age_int")) |>
+    dplyr::mutate(
+      broad_age_cat = dplyr::case_when(
+        age_int %in% seq(0L, 15L) ~ "0-15",
+        age_int %in% seq(16L, 49L) ~ "16-49",
+        age_int %in% seq(50L, 74L) ~ "50-74",
+        .default = "75+"
+      ),
+      across(broad_age_cat, forcats::fct_inorder),
+      .keep = "unused"
+    )
+}
+
+
+
+```
+
+
+```{r data-quality}
+national_count_contacts <- function(.data) {
+  .data |>
+    dplyr::mutate(
+      contacts = purrr::map(.data[["data"]], \(x) {
+        dplyr::summarise(x, across("projected_contacts", sum))
+      })
+    )
+}
+icb_count_contacts <- function(.data) {
+  .data |>
+    dplyr::mutate(
+      contacts = purrr::map(.data[["data"]], \(x) {
+        dplyr::summarise(x, across("projected_contacts", sum))
+      }),
+      .by = c("icb22cdh", "icb22nm")
+    )
+}
+
+
+n_contacts_init <- national_count_contacts(contacts_data)
+icb_n_contacts_init <- icb_count_contacts(contacts_data)
+
+
+# Exclude rows missing patient age
+valid_age_only <- contacts_data |>
+  dplyr::mutate(
+    across("data", \(x) {
+      purrr::map(x, \(x) {
+        dplyr::filter(x, dplyr::if_any("age_int", \(x) !is.na(x)))
+      })
+    })
+  )
+
+n_contacts_valid_age <- national_count_contacts(valid_age_only)
+icb_n_contacts_valid_age <- icb_count_contacts(valid_age_only)
+
+
+# Exclude rows with missing gender or gender recorded as "Unknown"
+fm_gender_only <- contacts_data |>
+  dplyr::mutate(
+    across("data", \(x) {
+      purrr::map(x, \(x) {
+        dplyr::filter(
+          x,
+          dplyr::if_any("gender_cat", \(x) x %in% c("Female", "Male"))
+        )
+      })
+    })
+  )
+
+n_contacts_fm_gender <- national_count_contacts(fm_gender_only)
+icb_n_contacts_fm_gender <- icb_count_contacts(fm_gender_only)
+
+
+# https://www.datadictionary.nhs.uk/data_elements/attendance_status.html
+# 5 - attended on time
+# 6 - attended late but was seen
+# 7 - attended late and was not seen
+# 2 - patient cancelled
+# 3 - DNA (without notice)
+# 4 - provider cancelled or postponed
+attended_only <- contacts_data |>
+  dplyr::filter(dplyr::if_any("attendance_status", \(x) x %in% c("5", "6")))
+
+n_contacts_attended <- national_count_contacts(attended_only)
+icb_n_contacts_attended <- icb_count_contacts(attended_only)
+
+
+england_only <- contacts_data |>
+  dplyr::mutate(
+    across("data", \(x) {
+      purrr::map(x, \(x) {
+        dplyr::filter(x, dplyr::if_any("lad18cd", \(x) !is.na(x)))
+      })
+    })
+  )
+
+n_contacts_england <- national_count_contacts(england_only)
+icb_n_contacts_england <- icb_count_contacts(england_only)
+
+
+```
+
+
+## National contacts projection by financial year
+
+
+```{r charts1}
+contacts_data <- contacts_data |>
+  dplyr::filter(if_any("consistent"))
+
+national_contacts <- contacts_data |>
+  dplyr::pull("data") |>
+  dplyr::bind_rows() |>
+  dplyr::summarise(
+    across(c("fin_year_popn", "projected_contacts"), sum),
+    .by = c("fin_year", "age_int", "gender_cat") # is gender still needed?
+  )
+
+national_contacts |>
+  add_broad_age_groups() |>
+  dplyr::summarise(
+    dplyr::across("projected_contacts", sum),
+    .by = c("fin_year", "broad_age_cat")
+  ) |>
+  ggplot2::ggplot(aes(fin_year, projected_contacts)) +
+  ggplot2::geom_line(
+    aes(colour = broad_age_cat, group = broad_age_cat),
+    linewidth = 1.8
+  ) +
+  ggplot2::labs(
+    title = "Projected contacts (national) by broad age group, 2022/23 - 2042/43",
+    caption = sub_wrap(
+      "Sources: NHS England Community Services Dataset (2022-23),",
+      "ONS Population projections"
+    ),
+    x = NULL,
+    y = NULL
+  ) +
+  ggplot2::scale_y_continuous(
+    labels = label_number(scale = 1e-6, suffix = "mn"),
+    limits = c(0, 6e7)
+  ) +
+  ggplot2::scale_x_discrete(
+    breaks = \(x) x[seq(1, length(x), 5)],
+    labels = \(x) sub("_", "/", x)
+  ) +
+  scale_colour_su(name = "Age group") +
+  su_chart_theme() +
+  ggplot2::theme(
+    legend.position = "inside",
+    legend.position.inside = c(0.9, 0.6)
+  )
+
+
+
+
+```
+
+
+
+## ICB-level contacts projection by financial year
+
+```{r charts2}
+icb_contacts <- contacts_data |>
+  dplyr::filter(if_any("icb22cdh", \(x) x == {{ selected_icb }})) |>
+  dplyr::pull("data") |>
+  dplyr::bind_rows() |>
+  dplyr::summarise(
+    across(c("fin_year_popn", "projected_contacts"), sum),
+    .by = c("fin_year", "age_int", "gender_cat") # is gender still needed?
+  )
+
+icb_contacts |>
+  add_broad_age_groups() |>
+  dplyr::summarise(
+    dplyr::across("projected_contacts", sum),
+    .by = c("fin_year", "broad_age_cat")
+  ) |>
+  ggplot2::ggplot(aes(fin_year, projected_contacts)) +
+  ggplot2::geom_line(
+    aes(colour = broad_age_cat, group = broad_age_cat),
+    linewidth = 1.8
+  ) +
+  ggplot2::labs(
+    title = "Projected contacts (single ICB) by broad age group, 2022/23 - 2042/43",
+    caption = sub_wrap(
+      "Sources: NHS England Community Services Dataset (2022-23),",
+      "ONS Population projections"
+    ),
+    x = NULL,
+    y = NULL
+  ) +
+  ggplot2::scale_y_continuous(
+    labels = label_number(scale = 1e-3, suffix = "k"),
+    limits = c(0, NA)
+  ) +
+  ggplot2::scale_x_discrete(
+    breaks = \(x) x[seq(1, length(x), 5)],
+    labels = \(x) sub("_", "/", x)
+  ) +
+  scale_colour_su(name = "Age group") +
+  su_chart_theme()
+
+
+
+```
+
+
+
+## Projected % change in total contacts over period, by age group
+
+```{r, charts3}
+list(national = national_contacts, icb = icb_contacts) |>
+  dplyr::bind_rows(.id = "type") |>
+  dplyr::filter(if_any("fin_year", \(x) grepl("^20[24]2", x))) |>
+  add_age_groups() |>
+  dplyr::summarise(
+    value = sum(.data[["projected_contacts"]]),
+    .by = c("type", "fin_year", "age_group_cat")
+  ) |>
+  tidyr::pivot_wider(
+    id_cols = c("type", "age_group_cat"),
+    names_from = "fin_year",
+    names_prefix = "yr_"
+  ) |>
+  dplyr::mutate(
+    pct_change = (.data[["yr_2042_43"]] - .data[["yr_2022_23"]]) /
+      .data[["yr_2022_23"]],
+    .keep = "unused"
+  ) |>
+  ggplot2::ggplot(aes(age_group_cat, pct_change)) +
+  ggplot2::geom_col(aes(fill = type), position = "dodge", width = 0.75) +
+  ggplot2::geom_hline(yintercept = 0, linewidth = 0.4, colour = text_grey) +
+  ggplot2::labs(
+    title = "Projected % change in total contacts, by age group, 2022/23 - 2042/43",
+    subtitle = sub_wrap(
+      "This chart shows changes within a single selected ICB compared to",
+      "national (England) changes. Change means the difference between",
+      "2022/23 annual contacts and projected 2042/43 annual contacts,",
+      "as a percentage of 2022/23 contacts."
+    ),
+    caption = sub_wrap(
+      "Sources: NHS England Community Services Dataset (2022-23),",
+      "ONS Population projections"
+    ),
+    x = "Age group",
+    y = "% change"
+  ) +
+  ggplot2::scale_y_continuous(
+    labels = label_percent(suffix = ""),
+    limits = c(-0.25, NA)
+  ) +
+  scale_fill_su(name = NULL) +
+  su_chart_theme() +
+  ggplot2::theme(
+    legend.position = "inside",
+    legend.position.inside = c(0.15, 0.72),
+    legend.text = element_text(margin = margin(l = 6), hjust = 0)
+  )
+
+
+```
+
+
+
+## Contacts per 1000 population, 2022/23, by age group
+
+```{r charts4}
+list(national = national_contacts, icb = icb_contacts) |>
+  dplyr::bind_rows(.id = "type") |>
+  dplyr::filter(if_any("fin_year", \(x) x == "2022_23")) |>
+  add_age_groups() |>
+  dplyr::summarise(
+    across(c("fin_year_popn", "projected_contacts"), sum),
+    .by = c("type", "age_group_cat")
+  ) |>
+  dplyr::mutate(
+    contacts_rate = .data[["projected_contacts"]] / .data[["fin_year_popn"]],
+    .keep = "unused"
+  ) |>
+  ggplot2::ggplot(aes(age_group_cat, contacts_rate)) +
+  ggplot2::geom_col(aes(fill = type), position = "dodge", width = 0.75) +
+  ggplot2::labs(
+    title = "Contacts per 1,000 population, 2022/23, by age group",
+    subtitle = sub_wrap(
+      "This chart shows the contact rate by age group within a single selected",
+      "ICB, compared to the national (England) rate."
+    ),
+    caption = sub_wrap(
+      "Sources: NHS England Community Services Dataset (2022-23),",
+      "ONS Population projections"
+    ),
+    x = "Age group",
+    y = "Contacts / 1000 people"
+  ) +
+  ggplot2::scale_y_continuous(labels = label_number(scale = 1e3)) +
+  scale_fill_su(name = NULL) +
+  su_chart_theme() +
+  ggplot2::theme(
+    legend.position = "inside",
+    legend.position.inside = c(0.15, 0.72),
+    legend.text = element_text(margin = margin(l = 6), hjust = 0)
+  )
+
+
+```


### PR DESCRIPTION
This PR:

* [x] Borrows the improved `build_datasets` process from branch issue11 (#11) to support easy data quality reporting
* [x] Creates chart creation functions in the development .qmd file, building in improvements to the theme
* [x] Amends the age grouping helper functions

Closes #25 and addresses #33 in quarto - but not in Shiny.